### PR TITLE
Enable the user to specify the collapsed state in the initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ struct Section {
   var items: [String]!
   var collapsed: Bool!
     
-  init(name: String, items: [String]) {
+  init(name: String, items: [String], collapsed: Bool = false) {
     self.name = name
     self.items = items
     self.collapsed = false

--- a/ios-swift-collapsible-table-section-in-grouped-section/ViewController.swift
+++ b/ios-swift-collapsible-table-section-in-grouped-section/ViewController.swift
@@ -19,10 +19,10 @@ class ViewController: UITableViewController {
         var items: [String]!
         var collapsed: Bool!
         
-        init(name: String, items: [String]) {
+        init(name: String, items: [String], collapsed: Bool = false) {
             self.name = name
             self.items = items
-            self.collapsed = true
+            self.collapsed = collapsed
         }
     }
     


### PR DESCRIPTION
When not specified, the standard value is still false.
Also, I switched the default state to false; in the project, it was
true.
